### PR TITLE
Update geo types dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ categories = ["algorithms"]
 
 [dependencies]
 clipper-sys = "0.2.0"
-geo-types = "0.4.3"
+geo-types = "0.5.0"


### PR DESCRIPTION
The `Clipper` trait depends on these definitions and is no longer interoperable with the new definitions.