### PR TITLE
Expose polygon offsets from clipper-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ keywords = ["geo", "polygon", "boolean"]
 categories = ["algorithms"]
 
 [dependencies]
-clipper-sys = { git = "ssh://git@github.com/jsadusk/clipper-sys" }
+clipper-sys = "0.3.1"
 geo-types = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ keywords = ["geo", "polygon", "boolean"]
 categories = ["algorithms"]
 
 [dependencies]
-clipper-sys = { path = "../clipper-sys" }
+clipper-sys = "0.3.1"
 geo-types = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ keywords = ["geo", "polygon", "boolean"]
 categories = ["algorithms"]
 
 [dependencies]
-clipper-sys = "0.2.0"
-geo-types = "0.5.0"
+clipper-sys = { git = "ssh://git@github.com/jsadusk/clipper-sys" }
+geo-types = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/lelongg/geo-clipper"
 documentation = "https://docs.rs/geo-clipper/"
 description = "Boolean operations on polygons"
-keywords = ["geo", "polygon", "boolean"]
+keywords = ["geo", "polygon", "boolean", "offset"]
 categories = ["algorithms"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ keywords = ["geo", "polygon", "boolean"]
 categories = ["algorithms"]
 
 [dependencies]
-clipper-sys = "0.3.1"
+clipper-sys = { path = "../clipper-sys" }
 geo-types = "0.6.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! This crate allows to perform boolean operations on polygons.
+//! This crate allows to perform boolean and offset operations on polygons.
 //!
 //! It makes use of [clipper-sys](https://github.com/lelongg/clipper-sys) which is a binding to the C++ version of [Clipper](http://www.angusj.com/delphi/clipper.php).
 //!
@@ -328,9 +328,9 @@ fn execute_boolean_operation<T: ToOwnedPolygon + ?Sized, U: ToOwnedPolygon + ?Si
     result
 }
 
-/// This trait defines the boolean and offset operations between polygons
+/// This trait defines the boolean and offset operations on polygons
 ///
-/// The `factor` parameter in its methods is used to scale shapes before and after applying the boolean operation
+/// The `factor` parameter in its methods is used to scale shapes before and after applying the operation
 /// to avoid precision loss since Clipper (the underlaying library) performs integer computation.
 pub trait Clipper {
     fn difference<T: ToOwnedPolygon + ?Sized>(&self, other: &T, factor: f64) -> MultiPolygon<f64>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,18 +328,16 @@ fn execute_boolean_operation<T: ToOwnedPolygon + ?Sized, U: ToOwnedPolygon + ?Si
     result
 }
 
-/// This trait defines the boolean operations between polygons.
+/// This trait defines the boolean and offset operations between polygons
 ///
 /// The `factor` parameter in its methods is used to scale shapes before and after applying the boolean operation
 /// to avoid precision loss since Clipper (the underlaying library) performs integer computation.
-pub trait Clipper<T: ?Sized> {
-    fn difference(&self, other: &T, factor: f64) -> MultiPolygon<f64>;
-    fn intersection(&self, other: &T, factor: f64) -> MultiPolygon<f64>;
-    fn union(&self, other: &T, factor: f64) -> MultiPolygon<f64>;
-    fn xor(&self, other: &T, factor: f64) -> MultiPolygon<f64>;
-}
-
-pub trait ClipperOffset {
+pub trait Clipper {
+    fn difference<T: ToOwnedPolygon + ?Sized>(&self, other: &T, factor: f64) -> MultiPolygon<f64>;
+    fn intersection<T: ToOwnedPolygon + ?Sized>(&self, other: &T, factor: f64)
+        -> MultiPolygon<f64>;
+    fn union<T: ToOwnedPolygon + ?Sized>(&self, other: &T, factor: f64) -> MultiPolygon<f64>;
+    fn xor<T: ToOwnedPolygon + ?Sized>(&self, other: &T, factor: f64) -> MultiPolygon<f64>;
     fn offset(
         &self,
         delta: f64,
@@ -349,25 +347,27 @@ pub trait ClipperOffset {
     ) -> MultiPolygon<f64>;
 }
 
-impl<T: ToOwnedPolygon + ?Sized, U: ToOwnedPolygon + ?Sized> Clipper<T> for U {
-    fn difference(&self, other: &T, factor: f64) -> MultiPolygon<f64> {
+impl<U: ToOwnedPolygon + ?Sized> Clipper for U {
+    fn difference<T: ToOwnedPolygon + ?Sized>(&self, other: &T, factor: f64) -> MultiPolygon<f64> {
         execute_boolean_operation(ClipType_ctDifference, self, other, factor)
     }
 
-    fn intersection(&self, other: &T, factor: f64) -> MultiPolygon<f64> {
+    fn intersection<T: ToOwnedPolygon + ?Sized>(
+        &self,
+        other: &T,
+        factor: f64,
+    ) -> MultiPolygon<f64> {
         execute_boolean_operation(ClipType_ctIntersection, self, other, factor)
     }
 
-    fn union(&self, other: &T, factor: f64) -> MultiPolygon<f64> {
+    fn union<T: ToOwnedPolygon + ?Sized>(&self, other: &T, factor: f64) -> MultiPolygon<f64> {
         execute_boolean_operation(ClipType_ctUnion, self, other, factor)
     }
 
-    fn xor(&self, other: &T, factor: f64) -> MultiPolygon<f64> {
+    fn xor<T: ToOwnedPolygon + ?Sized>(&self, other: &T, factor: f64) -> MultiPolygon<f64> {
         execute_boolean_operation(ClipType_ctXor, self, other, factor)
     }
-}
 
-impl<T: ToOwnedPolygon + ?Sized> ClipperOffset for T {
     fn offset(
         &self,
         delta: f64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ use clipper_sys::{
     PolyFillType_pftNonZero, PolyType, PolyType_ptClip, PolyType_ptSubject,
     Polygon as ClipperPolygon, Polygons, Vertice,
 };
-use geo_types::{Coordinate, LineString, MultiLineString, MultiPolygon, Polygon};
+use geo_types::{Coordinate, LineString, MultiPolygon, Polygon};
 use std::convert::TryInto;
 
 #[derive(Clone, Copy)]
@@ -136,27 +136,6 @@ impl From<ClipperPolygons> for MultiPolygon<f64> {
     }
 }
 
-impl From<ClipperPolygons> for MultiLineString<f64> {
-    fn from(polygons: ClipperPolygons) -> Self {
-        MultiLineString(
-            polygons
-                .polygons
-                .polygons()
-                .iter()
-                .flat_map(|polygon| {
-                    polygon.paths().iter().map(|path| {
-                        ClipperPath {
-                            path: *path,
-                            factor: polygons.factor,
-                        }
-                        .into()
-                    })
-                })
-                .collect(),
-        )
-    }
-}
-
 impl From<ClipperPath> for LineString<f64> {
     fn from(path: ClipperPath) -> Self {
         path.path
@@ -169,14 +148,6 @@ impl From<ClipperPath> for LineString<f64> {
             .collect()
     }
 }
-
-pub trait OpenPath {}
-pub trait ClosedPoly {}
-
-impl OpenPath for MultiLineString<f64> {}
-impl OpenPath for LineString<f64> {}
-impl ClosedPoly for MultiPolygon<f64> {}
-impl ClosedPoly for Polygon<f64> {}
 
 #[doc(hidden)]
 pub struct OwnedPolygon {
@@ -208,17 +179,6 @@ impl ToOwnedPolygon for Polygon<f64> {
             vertices: Vec::with_capacity(1),
         }
         .add_polygon(self, poly_type, factor)
-    }
-}
-
-impl ToOwnedPolygon for MultiLineString<f64> {
-    fn to_polygon_owned(&self, poly_type: PolyType, factor: f64) -> OwnedPolygon {
-        OwnedPolygon {
-            polygons: Vec::with_capacity(self.0.len()),
-            paths: Vec::with_capacity(self.0.len()),
-            vertices: Vec::with_capacity(self.0.len()),
-        }
-        .add_line_strings(self, poly_type, factor)
     }
 }
 
@@ -262,45 +222,6 @@ impl OwnedPolygon {
                 vertices: std::ptr::null_mut(),
                 vertices_count: 0,
                 closed: 1,
-            });
-        }
-
-        self.polygons.push(ClipperPolygon {
-            paths: std::ptr::null_mut(),
-            paths_count: 0,
-            type_: poly_type,
-        });
-
-        self
-    }
-
-    fn add_line_strings(
-        mut self,
-        line_strings: &MultiLineString<f64>,
-        poly_type: PolyType,
-        factor: f64,
-    ) -> Self {
-        let path_count = line_strings.0.len();
-        self.paths.push(Vec::with_capacity(path_count));
-        self.vertices.push(Vec::with_capacity(path_count));
-        let last_path = self.paths.last_mut().unwrap();
-        let last_path_vertices = self.vertices.last_mut().unwrap();
-
-        for line_string in line_strings.0.iter() {
-            last_path_vertices.push(Vec::with_capacity(line_string.0.len().saturating_sub(1)));
-            let last_vertices = last_path_vertices.last_mut().unwrap();
-
-            for coordinate in line_string.0.iter() {
-                last_vertices.push([
-                    (coordinate.x * factor) as i64,
-                    (coordinate.y * factor) as i64,
-                ]);
-            }
-
-            last_path.push(Path {
-                vertices: std::ptr::null_mut(),
-                vertices_count: 0,
-                closed: 0,
             });
         }
 
@@ -368,16 +289,12 @@ fn execute_offset_operation<T: ToOwnedPolygon + ?Sized>(
     result
 }
 
-fn execute_boolean_operation<
-    T: ToOwnedPolygon + ?Sized,
-    U: ToOwnedPolygon + ?Sized,
-    R: From<ClipperPolygons>,
->(
+fn execute_boolean_operation<T: ToOwnedPolygon + ?Sized, U: ToOwnedPolygon + ?Sized>(
     clip_type: ClipType,
     subject_polygons: &T,
     clip_polygons: &U,
     factor: f64,
-) -> R {
+) -> MultiPolygon<f64> {
     let mut subject_owned = subject_polygons.to_polygon_owned(PolyType_ptSubject, factor);
     let mut clip_owned = clip_polygons.to_polygon_owned(PolyType_ptClip, factor);
     let mut polygons: Vec<ClipperPolygon> = subject_owned
@@ -415,28 +332,12 @@ fn execute_boolean_operation<
 ///
 /// The `factor` parameter in its methods is used to scale shapes before and after applying the boolean operation
 /// to avoid precision loss since Clipper (the underlaying library) performs integer computation.
-
 pub trait Clipper {
-    fn difference<T: ToOwnedPolygon + ClosedPoly + ?Sized>(
-        &self,
-        other: &T,
-        factor: f64,
-    ) -> MultiPolygon<f64>;
-    fn intersection<T: ToOwnedPolygon + ClosedPoly + ?Sized>(
-        &self,
-        other: &T,
-        factor: f64,
-    ) -> MultiPolygon<f64>;
-    fn union<T: ToOwnedPolygon + ClosedPoly + ?Sized>(
-        &self,
-        other: &T,
-        factor: f64,
-    ) -> MultiPolygon<f64>;
-    fn xor<T: ToOwnedPolygon + ClosedPoly + ?Sized>(
-        &self,
-        other: &T,
-        factor: f64,
-    ) -> MultiPolygon<f64>;
+    fn difference<T: ToOwnedPolygon + ?Sized>(&self, other: &T, factor: f64) -> MultiPolygon<f64>;
+    fn intersection<T: ToOwnedPolygon + ?Sized>(&self, other: &T, factor: f64)
+        -> MultiPolygon<f64>;
+    fn union<T: ToOwnedPolygon + ?Sized>(&self, other: &T, factor: f64) -> MultiPolygon<f64>;
+    fn xor<T: ToOwnedPolygon + ?Sized>(&self, other: &T, factor: f64) -> MultiPolygon<f64>;
     fn offset(
         &self,
         delta: f64,
@@ -446,29 +347,12 @@ pub trait Clipper {
     ) -> MultiPolygon<f64>;
 }
 
-pub trait ClipperOpen {
-    fn difference<T: ToOwnedPolygon + ClosedPoly + ?Sized>(
-        &self,
-        other: &T,
-        factor: f64,
-    ) -> MultiLineString<f64>;
-    fn intersection<T: ToOwnedPolygon + ClosedPoly + ?Sized>(
-        &self,
-        other: &T,
-        factor: f64,
-    ) -> MultiLineString<f64>;
-}
-
-impl<U: ToOwnedPolygon + ClosedPoly + ?Sized> Clipper for U {
-    fn difference<T: ToOwnedPolygon + ClosedPoly + ?Sized>(
-        &self,
-        other: &T,
-        factor: f64,
-    ) -> MultiPolygon<f64> {
+impl<U: ToOwnedPolygon + ?Sized> Clipper for U {
+    fn difference<T: ToOwnedPolygon + ?Sized>(&self, other: &T, factor: f64) -> MultiPolygon<f64> {
         execute_boolean_operation(ClipType_ctDifference, self, other, factor)
     }
 
-    fn intersection<T: ToOwnedPolygon + ClosedPoly + ?Sized>(
+    fn intersection<T: ToOwnedPolygon + ?Sized>(
         &self,
         other: &T,
         factor: f64,
@@ -476,19 +360,11 @@ impl<U: ToOwnedPolygon + ClosedPoly + ?Sized> Clipper for U {
         execute_boolean_operation(ClipType_ctIntersection, self, other, factor)
     }
 
-    fn union<T: ToOwnedPolygon + ClosedPoly + ?Sized>(
-        &self,
-        other: &T,
-        factor: f64,
-    ) -> MultiPolygon<f64> {
+    fn union<T: ToOwnedPolygon + ?Sized>(&self, other: &T, factor: f64) -> MultiPolygon<f64> {
         execute_boolean_operation(ClipType_ctUnion, self, other, factor)
     }
 
-    fn xor<T: ToOwnedPolygon + ClosedPoly + ?Sized>(
-        &self,
-        other: &T,
-        factor: f64,
-    ) -> MultiPolygon<f64> {
+    fn xor<T: ToOwnedPolygon + ?Sized>(&self, other: &T, factor: f64) -> MultiPolygon<f64> {
         execute_boolean_operation(ClipType_ctXor, self, other, factor)
     }
 
@@ -503,30 +379,12 @@ impl<U: ToOwnedPolygon + ClosedPoly + ?Sized> Clipper for U {
     }
 }
 
-impl<U: ToOwnedPolygon + OpenPath + ?Sized> ClipperOpen for U {
-    fn difference<T: ToOwnedPolygon + ClosedPoly + ?Sized>(
-        &self,
-        other: &T,
-        factor: f64,
-    ) -> MultiLineString<f64> {
-        execute_boolean_operation(ClipType_ctDifference, self, other, factor)
-    }
-
-    fn intersection<T: ToOwnedPolygon + ClosedPoly + ?Sized>(
-        &self,
-        other: &T,
-        factor: f64,
-    ) -> MultiLineString<f64> {
-        execute_boolean_operation(ClipType_ctIntersection, self, other, factor)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /*#[test]
-    fn test_closed_clip() {
+    #[test]
+    fn test() {
         let expected = MultiPolygon(vec![Polygon::new(
             LineString(vec![
                 Coordinate { x: 240.0, y: 200.0 },
@@ -570,7 +428,7 @@ mod tests {
     }
 
     #[test]
-    fn test_closed_offset() {
+    fn test_offset() {
         let expected = MultiPolygon(vec![Polygon::new(
             LineString(vec![
                 Coordinate { x: 265.0, y: 205.0 },
@@ -601,37 +459,5 @@ mod tests {
 
         let result = subject.offset(5.0, JoinType::Miter(5.0), EndType::ClosedPolygon, 1.0);
         assert_eq!(expected, result)
-    }*/
-
-    #[test]
-    fn test_open_clip() {
-        let expected = MultiLineString(vec![
-            LineString(vec![
-                Coordinate { x: 100.0, y: 100.0 },
-                Coordinate { x: 200.0, y: 100.0 },
-            ]),
-            LineString(vec![
-                Coordinate { x: 300.0, y: 100.0 },
-                Coordinate { x: 400.0, y: 100.0 },
-            ]),
-        ]);
-
-        let subject = MultiLineString(vec![LineString(vec![
-            Coordinate { x: 100.0, y: 100.0 },
-            Coordinate { x: 400.0, y: 100.0 },
-        ])]);
-        let clip = Polygon::new(
-            LineString(vec![
-                Coordinate { x: 200.0, y: 50.0 },
-                Coordinate { x: 200.0, y: 150.0 },
-                Coordinate { x: 300.0, y: 150.0 },
-                Coordinate { x: 300.0, y: 50.0 },
-                Coordinate { x: 200.0, y: 50.0 },
-            ]),
-            vec![],
-        );
-
-        let result = subject.difference(&clip, 1.0);
-        assert_eq!(expected, result);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,7 +352,7 @@ impl<T: ToOwnedPolygon + ?Sized> ClipperOffset for T {
         end_type: EndType,
         factor: f64,
     ) -> MultiPolygon<f64> {
-        execute_offset_operation(self, delta, join_type, end_type, factor)
+        execute_offset_operation(self, delta * factor, join_type, end_type, factor)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,6 +314,9 @@ pub trait Clipper<T: ?Sized> {
     fn intersection(&self, other: &T, factor: f64) -> MultiPolygon<f64>;
     fn union(&self, other: &T, factor: f64) -> MultiPolygon<f64>;
     fn xor(&self, other: &T, factor: f64) -> MultiPolygon<f64>;
+}
+
+pub trait ClipperOffset {
     fn offset(
         &self,
         delta: f64,
@@ -339,7 +342,9 @@ impl<T: ToOwnedPolygon + ?Sized, U: ToOwnedPolygon + ?Sized> Clipper<T> for U {
     fn xor(&self, other: &T, factor: f64) -> MultiPolygon<f64> {
         execute_boolean_operation(ClipType_ctXor, self, other, factor)
     }
+}
 
+impl<T: ToOwnedPolygon + ?Sized> ClipperOffset for T {
     fn offset(
         &self,
         delta: f64,


### PR DESCRIPTION
This adds a new ClipperOffset trait that exposes offsetting functionality from clipper-sys. This relies on a related PR on clipper-sys, https://github.com/lelongg/clipper-sys/pull/4 which changes the interface to allow offsetting multiple polygons. This also updates the geo-types version to the latest.

This PR temporarily points to my fork of clipper-sys. I can change the dependency if the related PR merges.