### PR TITLE
Clipper operations on openpaths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ keywords = ["geo", "polygon", "boolean", "offset"]
 categories = ["algorithms"]
 
 [dependencies]
-clipper-sys = "0.3.1"
+clipper-sys = { git = "git://github.com/jsadusk/clipper-sys" }
 geo-types = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ keywords = ["geo", "polygon", "boolean", "offset"]
 categories = ["algorithms"]
 
 [dependencies]
-clipper-sys = { git = "git://github.com/jsadusk/clipper-sys" }
+clipper-sys = "0.3.2"
 geo-types = "0.6.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,9 @@ impl From<ClipperPath> for LineString<f64> {
     }
 }
 
+/// Marker trait to signify a type as an open path type
 pub trait OpenPath {}
+/// Marker trait to signify a type as an closed polygon type
 pub trait ClosedPoly {}
 
 impl OpenPath for MultiLineString<f64> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,6 +446,11 @@ pub trait Clipper {
     ) -> MultiPolygon<f64>;
 }
 
+/// This trait defines the boolean and offset operations between open paths and polygons
+/// It is a subset of the operations for polygons
+///
+/// The `factor` parameter in its methods is used to scale shapes before and after applying the boolean operation
+/// to avoid precision loss since Clipper (the underlaying library) performs integer computation.
 pub trait ClipperOpen {
     fn difference<T: ToOwnedPolygon + ClosedPoly + ?Sized>(
         &self,


### PR DESCRIPTION
This depends on PR https://github.com/lelongg/clipper-sys/pull/5 on clipper-sys. This exposes all of the open path operations that make sense in Clipper. Notably, difference, intersection and offset. It implements them as a new trait because not all functions are present. This attempts to be type safe to the type of geometry you are operating on, as opposed to clipper itself which requires you to mark an open path as open, or a closed polygon as closed.