### PR TITLE
Implement all clipper operations for integer polygon types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -708,6 +708,9 @@ pub trait Clipper {
     ) -> MultiPolygon<f64>;
 }
 
+/// This trait defines the boolean and offset operations on polygons, for integer coordinate types
+///
+/// There is no `factor`, since polygons are already in integer form
 pub trait ClipperInt {
     fn difference<T: ToOwnedPolygonInt + ClosedPoly + ?Sized>(
         &self,
@@ -747,6 +750,10 @@ pub trait ClipperOpen {
     ) -> MultiPolygon<f64>;
 }
 
+/// This trait defines the boolean and offset operations between open paths and polygons, for integer coordinate types
+/// It is a subset of the operations for polygons
+///
+/// There is no `factor`, since polygons are already in integer form
 pub trait ClipperOpenInt {
     fn difference<T: ToOwnedPolygonInt + ClosedPoly + ?Sized>(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ use clipper_sys::{
     PolyFillType_pftNonZero, PolyType, PolyType_ptClip, PolyType_ptSubject,
     Polygon as ClipperPolygon, Polygons, Vertice,
 };
-use geo_types::{Coordinate, LineString, MultiLineString, MultiPolygon, Polygon};
+use geo_types::{Coordinate, CoordinateType, LineString, MultiLineString, MultiPolygon, Polygon};
 use std::convert::TryInto;
 
 #[derive(Clone, Copy)]
@@ -101,6 +101,37 @@ struct ClipperPolygons {
 struct ClipperPath {
     pub path: Path,
     pub factor: f64,
+}
+
+impl From<ClipperPolygons> for MultiPolygon<i64> {
+    fn from(polygons: ClipperPolygons) -> Self {
+        polygons
+            .polygons
+            .polygons()
+            .iter()
+            .filter_map(|polygon| {
+                let paths = polygon.paths();
+                Some(Polygon::new(
+                    ClipperPath {
+                        path: *paths.first()?,
+                        factor: polygons.factor,
+                    }
+                    .into(),
+                    paths
+                        .iter()
+                        .skip(1)
+                        .map(|path| {
+                            ClipperPath {
+                                path: *path,
+                                factor: polygons.factor,
+                            }
+                            .into()
+                        })
+                        .collect(),
+                ))
+            })
+            .collect()
+    }
 }
 
 impl From<ClipperPolygons> for MultiPolygon<f64> {
@@ -155,6 +186,27 @@ impl From<ClipperPolygons> for MultiLineString<f64> {
     }
 }
 
+impl From<ClipperPolygons> for MultiLineString<i64> {
+    fn from(polygons: ClipperPolygons) -> Self {
+        MultiLineString(
+            polygons
+                .polygons
+                .polygons()
+                .iter()
+                .flat_map(|polygon| {
+                    polygon.paths().iter().map(|path| {
+                        ClipperPath {
+                            path: *path,
+                            factor: polygons.factor,
+                        }
+                        .into()
+                    })
+                })
+                .collect(),
+        )
+    }
+}
+
 impl From<ClipperPath> for LineString<f64> {
     fn from(path: ClipperPath) -> Self {
         path.path
@@ -168,15 +220,28 @@ impl From<ClipperPath> for LineString<f64> {
     }
 }
 
+impl From<ClipperPath> for LineString<i64> {
+    fn from(path: ClipperPath) -> Self {
+        path.path
+            .vertices()
+            .iter()
+            .map(|vertice| Coordinate {
+                x: vertice[0],
+                y: vertice[1],
+            })
+            .collect()
+    }
+}
+
 /// Marker trait to signify a type as an open path type
 pub trait OpenPath {}
 /// Marker trait to signify a type as an closed polygon type
 pub trait ClosedPoly {}
 
-impl OpenPath for MultiLineString<f64> {}
-impl OpenPath for LineString<f64> {}
-impl ClosedPoly for MultiPolygon<f64> {}
-impl ClosedPoly for Polygon<f64> {}
+impl<T: CoordinateType> OpenPath for MultiLineString<T> {}
+impl<T: CoordinateType> OpenPath for LineString<T> {}
+impl<T: CoordinateType> ClosedPoly for MultiPolygon<T> {}
+impl<T: CoordinateType> ClosedPoly for Polygon<T> {}
 
 #[doc(hidden)]
 pub struct OwnedPolygon {
@@ -222,6 +287,43 @@ impl ToOwnedPolygon for MultiLineString<f64> {
     }
 }
 
+pub trait ToOwnedPolygonInt {
+    fn to_polygon_owned(&self, poly_type: PolyType) -> OwnedPolygon;
+}
+
+impl ToOwnedPolygonInt for MultiPolygon<i64> {
+    fn to_polygon_owned(&self, poly_type: PolyType) -> OwnedPolygon {
+        OwnedPolygon {
+            polygons: Vec::with_capacity(self.0.len()),
+            paths: Vec::with_capacity(self.0.len()),
+            vertices: Vec::with_capacity(self.0.len()),
+        }
+        .add_polygons_int(self, poly_type)
+    }
+}
+
+impl ToOwnedPolygonInt for Polygon<i64> {
+    fn to_polygon_owned(&self, poly_type: PolyType) -> OwnedPolygon {
+        OwnedPolygon {
+            polygons: Vec::with_capacity(1),
+            paths: Vec::with_capacity(1),
+            vertices: Vec::with_capacity(1),
+        }
+        .add_polygon_int(self, poly_type)
+    }
+}
+
+impl ToOwnedPolygonInt for MultiLineString<i64> {
+    fn to_polygon_owned(&self, poly_type: PolyType) -> OwnedPolygon {
+        OwnedPolygon {
+            polygons: Vec::with_capacity(self.0.len()),
+            paths: Vec::with_capacity(self.0.len()),
+            vertices: Vec::with_capacity(self.0.len()),
+        }
+        .add_line_strings_int(self, poly_type)
+    }
+}
+
 impl OwnedPolygon {
     pub fn get_clipper_polygons(&mut self) -> &Vec<ClipperPolygon> {
         for (polygon, (paths, paths_vertices)) in self
@@ -256,6 +358,37 @@ impl OwnedPolygon {
                     (coordinate.x * factor) as i64,
                     (coordinate.y * factor) as i64,
                 ]);
+            }
+
+            last_path.push(Path {
+                vertices: std::ptr::null_mut(),
+                vertices_count: 0,
+                closed: 1,
+            });
+        }
+
+        self.polygons.push(ClipperPolygon {
+            paths: std::ptr::null_mut(),
+            paths_count: 0,
+            type_: poly_type,
+        });
+
+        self
+    }
+
+    fn add_polygon_int(mut self, polygon: &Polygon<i64>, poly_type: PolyType) -> Self {
+        let path_count = polygon.interiors().len() + 1;
+        self.paths.push(Vec::with_capacity(path_count));
+        self.vertices.push(Vec::with_capacity(path_count));
+        let last_path = self.paths.last_mut().unwrap();
+        let last_path_vertices = self.vertices.last_mut().unwrap();
+
+        for line_string in std::iter::once(polygon.exterior()).chain(polygon.interiors().iter()) {
+            last_path_vertices.push(Vec::with_capacity(line_string.0.len().saturating_sub(1)));
+            let last_vertices = last_path_vertices.last_mut().unwrap();
+
+            for coordinate in line_string.0.iter().skip(1) {
+                last_vertices.push([coordinate.x, coordinate.y])
             }
 
             last_path.push(Path {
@@ -313,9 +446,50 @@ impl OwnedPolygon {
         self
     }
 
+    fn add_line_strings_int(
+        mut self,
+        line_strings: &MultiLineString<i64>,
+        poly_type: PolyType,
+    ) -> Self {
+        let path_count = line_strings.0.len();
+        self.paths.push(Vec::with_capacity(path_count));
+        self.vertices.push(Vec::with_capacity(path_count));
+        let last_path = self.paths.last_mut().unwrap();
+        let last_path_vertices = self.vertices.last_mut().unwrap();
+
+        for line_string in line_strings.0.iter() {
+            last_path_vertices.push(Vec::with_capacity(line_string.0.len().saturating_sub(1)));
+            let last_vertices = last_path_vertices.last_mut().unwrap();
+
+            for coordinate in line_string.0.iter() {
+                last_vertices.push([coordinate.x, coordinate.y]);
+            }
+
+            last_path.push(Path {
+                vertices: std::ptr::null_mut(),
+                vertices_count: 0,
+                closed: 0,
+            });
+        }
+
+        self.polygons.push(ClipperPolygon {
+            paths: std::ptr::null_mut(),
+            paths_count: 0,
+            type_: poly_type,
+        });
+
+        self
+    }
+
     fn add_polygons(self, polygon: &MultiPolygon<f64>, poly_type: PolyType, factor: f64) -> Self {
         polygon.0.iter().fold(self, |polygons, polygon| {
             polygons.add_polygon(polygon, poly_type, factor)
+        })
+    }
+
+    fn add_polygons_int(self, polygon: &MultiPolygon<i64>, poly_type: PolyType) -> Self {
+        polygon.0.iter().fold(self, |polygons, polygon| {
+            polygons.add_polygon_int(polygon, poly_type)
         })
     }
 }
@@ -368,6 +542,53 @@ fn execute_offset_operation<T: ToOwnedPolygon + ?Sized>(
     result
 }
 
+fn execute_offset_operation_int<T: ToOwnedPolygonInt + ?Sized>(
+    polygons: &T,
+    delta: f64,
+    jt: JoinType,
+    et: EndType,
+) -> MultiPolygon<i64> {
+    let miter_limit = match jt {
+        JoinType::Miter(limit) => limit,
+        _ => 0.0,
+    };
+
+    let round_precision = match jt {
+        JoinType::Round(precision) => precision,
+        _ => match et {
+            EndType::OpenRound(precision) => precision,
+            _ => 0.0,
+        },
+    };
+
+    let mut owned = polygons.to_polygon_owned(PolyType_ptSubject);
+    let mut get_clipper = owned.get_clipper_polygons().clone();
+    let clipper_polygons = Polygons {
+        polygons: get_clipper.as_mut_ptr(),
+        polygons_count: get_clipper.len().try_into().unwrap(),
+    };
+    let solution = unsafe {
+        offset(
+            miter_limit,
+            round_precision,
+            jt.into(),
+            et.into(),
+            clipper_polygons,
+            delta,
+        )
+    };
+
+    let result = ClipperPolygons {
+        polygons: solution,
+        factor: 0.0,
+    }
+    .into();
+    unsafe {
+        free_polygons(solution);
+    }
+    result
+}
+
 fn execute_boolean_operation<
     T: ToOwnedPolygon + ?Sized,
     U: ToOwnedPolygon + ?Sized,
@@ -411,6 +632,48 @@ fn execute_boolean_operation<
     result
 }
 
+fn execute_boolean_operation_int<
+    T: ToOwnedPolygonInt + ?Sized,
+    U: ToOwnedPolygonInt + ?Sized,
+    R: From<ClipperPolygons>,
+>(
+    clip_type: ClipType,
+    subject_polygons: &T,
+    clip_polygons: &U,
+) -> R {
+    let mut subject_owned = subject_polygons.to_polygon_owned(PolyType_ptSubject);
+    let mut clip_owned = clip_polygons.to_polygon_owned(PolyType_ptClip);
+    let mut polygons: Vec<ClipperPolygon> = subject_owned
+        .get_clipper_polygons()
+        .iter()
+        .chain(clip_owned.get_clipper_polygons().iter())
+        .cloned()
+        .collect();
+    let clipper_polygons = Polygons {
+        polygons: polygons.as_mut_ptr(),
+        polygons_count: polygons.len().try_into().unwrap(),
+    };
+
+    let solution = unsafe {
+        execute(
+            clip_type,
+            clipper_polygons,
+            PolyFillType_pftNonZero,
+            PolyFillType_pftNonZero,
+        )
+    };
+
+    let result = ClipperPolygons {
+        polygons: solution,
+        factor: 0.0,
+    }
+    .into();
+    unsafe {
+        free_polygons(solution);
+    }
+    result
+}
+
 /// This trait defines the boolean and offset operations on polygons
 ///
 /// The `factor` parameter in its methods is used to scale shapes before and after applying the operation
@@ -445,6 +708,20 @@ pub trait Clipper {
     ) -> MultiPolygon<f64>;
 }
 
+pub trait ClipperInt {
+    fn difference<T: ToOwnedPolygonInt + ClosedPoly + ?Sized>(
+        &self,
+        other: &T,
+    ) -> MultiPolygon<i64>;
+    fn intersection<T: ToOwnedPolygonInt + ClosedPoly + ?Sized>(
+        &self,
+        other: &T,
+    ) -> MultiPolygon<i64>;
+    fn union<T: ToOwnedPolygonInt + ClosedPoly + ?Sized>(&self, other: &T) -> MultiPolygon<i64>;
+    fn xor<T: ToOwnedPolygonInt + ClosedPoly + ?Sized>(&self, other: &T) -> MultiPolygon<i64>;
+    fn offset(&self, delta: f64, join_type: JoinType, end_type: EndType) -> MultiPolygon<i64>;
+}
+
 /// This trait defines the boolean and offset operations between open paths and polygons
 /// It is a subset of the operations for polygons
 ///
@@ -468,6 +745,18 @@ pub trait ClipperOpen {
         end_type: EndType,
         factor: f64,
     ) -> MultiPolygon<f64>;
+}
+
+pub trait ClipperOpenInt {
+    fn difference<T: ToOwnedPolygonInt + ClosedPoly + ?Sized>(
+        &self,
+        other: &T,
+    ) -> MultiLineString<i64>;
+    fn intersection<T: ToOwnedPolygonInt + ClosedPoly + ?Sized>(
+        &self,
+        other: &T,
+    ) -> MultiLineString<i64>;
+    fn offset(&self, delta: f64, join_type: JoinType, end_type: EndType) -> MultiPolygon<i64>;
 }
 
 impl<U: ToOwnedPolygon + ClosedPoly + ?Sized> Clipper for U {
@@ -514,6 +803,34 @@ impl<U: ToOwnedPolygon + ClosedPoly + ?Sized> Clipper for U {
     }
 }
 
+impl<U: ToOwnedPolygonInt + ClosedPoly + ?Sized> ClipperInt for U {
+    fn difference<T: ToOwnedPolygonInt + ClosedPoly + ?Sized>(
+        &self,
+        other: &T,
+    ) -> MultiPolygon<i64> {
+        execute_boolean_operation_int(ClipType_ctDifference, self, other)
+    }
+
+    fn intersection<T: ToOwnedPolygonInt + ClosedPoly + ?Sized>(
+        &self,
+        other: &T,
+    ) -> MultiPolygon<i64> {
+        execute_boolean_operation_int(ClipType_ctIntersection, self, other)
+    }
+
+    fn union<T: ToOwnedPolygonInt + ClosedPoly + ?Sized>(&self, other: &T) -> MultiPolygon<i64> {
+        execute_boolean_operation_int(ClipType_ctUnion, self, other)
+    }
+
+    fn xor<T: ToOwnedPolygonInt + ClosedPoly + ?Sized>(&self, other: &T) -> MultiPolygon<i64> {
+        execute_boolean_operation_int(ClipType_ctXor, self, other)
+    }
+
+    fn offset(&self, delta: f64, join_type: JoinType, end_type: EndType) -> MultiPolygon<i64> {
+        execute_offset_operation_int(self, delta, join_type, end_type)
+    }
+}
+
 impl<U: ToOwnedPolygon + OpenPath + ?Sized> ClipperOpen for U {
     fn difference<T: ToOwnedPolygon + ClosedPoly + ?Sized>(
         &self,
@@ -539,6 +856,26 @@ impl<U: ToOwnedPolygon + OpenPath + ?Sized> ClipperOpen for U {
         factor: f64,
     ) -> MultiPolygon<f64> {
         execute_offset_operation(self, delta * factor, join_type, end_type, factor)
+    }
+}
+
+impl<U: ToOwnedPolygonInt + OpenPath + ?Sized> ClipperOpenInt for U {
+    fn difference<T: ToOwnedPolygonInt + ClosedPoly + ?Sized>(
+        &self,
+        other: &T,
+    ) -> MultiLineString<i64> {
+        execute_boolean_operation_int(ClipType_ctDifference, self, other)
+    }
+
+    fn intersection<T: ToOwnedPolygonInt + ClosedPoly + ?Sized>(
+        &self,
+        other: &T,
+    ) -> MultiLineString<i64> {
+        execute_boolean_operation_int(ClipType_ctIntersection, self, other)
+    }
+
+    fn offset(&self, delta: f64, join_type: JoinType, end_type: EndType) -> MultiPolygon<i64> {
+        execute_offset_operation_int(self, delta, join_type, end_type)
     }
 }
 
@@ -591,6 +928,50 @@ mod tests {
     }
 
     #[test]
+    fn test_closed_clip_int() {
+        let expected = MultiPolygon(vec![Polygon::new(
+            LineString(vec![
+                Coordinate { x: 240, y: 200 },
+                Coordinate { x: 190, y: 200 },
+                Coordinate { x: 190, y: 150 },
+                Coordinate { x: 240, y: 150 },
+            ]),
+            vec![LineString(vec![
+                Coordinate { x: 200, y: 190 },
+                Coordinate { x: 230, y: 190 },
+                Coordinate { x: 215, y: 160 },
+            ])],
+        )]);
+
+        let subject = Polygon::new(
+            LineString(vec![
+                Coordinate { x: 180, y: 200 },
+                Coordinate { x: 260, y: 200 },
+                Coordinate { x: 260, y: 150 },
+                Coordinate { x: 180, y: 150 },
+            ]),
+            vec![LineString(vec![
+                Coordinate { x: 215, y: 160 },
+                Coordinate { x: 230, y: 190 },
+                Coordinate { x: 200, y: 190 },
+            ])],
+        );
+
+        let clip = Polygon::new(
+            LineString(vec![
+                Coordinate { x: 190, y: 210 },
+                Coordinate { x: 240, y: 210 },
+                Coordinate { x: 240, y: 130 },
+                Coordinate { x: 190, y: 130 },
+            ]),
+            vec![],
+        );
+
+        let result = subject.intersection(&clip);
+        assert_eq!(expected, result);
+    }
+
+    #[test]
     fn test_closed_offset() {
         let expected = MultiPolygon(vec![Polygon::new(
             LineString(vec![
@@ -621,6 +1002,40 @@ mod tests {
         );
 
         let result = subject.offset(5.0, JoinType::Miter(5.0), EndType::ClosedPolygon, 1.0);
+        assert_eq!(expected, result)
+    }
+
+    #[test]
+    fn test_closed_offset_int() {
+        let expected = MultiPolygon(vec![Polygon::new(
+            LineString(vec![
+                Coordinate { x: 265, y: 205 },
+                Coordinate { x: 175, y: 205 },
+                Coordinate { x: 175, y: 145 },
+                Coordinate { x: 265, y: 145 },
+            ]),
+            vec![LineString(vec![
+                Coordinate { x: 208, y: 185 },
+                Coordinate { x: 222, y: 185 },
+                Coordinate { x: 215, y: 170 },
+            ])],
+        )]);
+
+        let subject = Polygon::new(
+            LineString(vec![
+                Coordinate { x: 180, y: 200 },
+                Coordinate { x: 260, y: 200 },
+                Coordinate { x: 260, y: 150 },
+                Coordinate { x: 180, y: 150 },
+            ]),
+            vec![LineString(vec![
+                Coordinate { x: 215, y: 160 },
+                Coordinate { x: 230, y: 190 },
+                Coordinate { x: 200, y: 190 },
+            ])],
+        );
+
+        let result = subject.offset(5.0, JoinType::Miter(5.0), EndType::ClosedPolygon);
         assert_eq!(expected, result)
     }
 
@@ -657,6 +1072,38 @@ mod tests {
     }
 
     #[test]
+    fn test_open_clip_int() {
+        let expected = MultiLineString(vec![
+            LineString(vec![
+                Coordinate { x: 200, y: 100 },
+                Coordinate { x: 100, y: 100 },
+            ]),
+            LineString(vec![
+                Coordinate { x: 400, y: 100 },
+                Coordinate { x: 300, y: 100 },
+            ]),
+        ]);
+
+        let subject = MultiLineString(vec![LineString(vec![
+            Coordinate { x: 100, y: 100 },
+            Coordinate { x: 400, y: 100 },
+        ])]);
+        let clip = Polygon::new(
+            LineString(vec![
+                Coordinate { x: 200, y: 50 },
+                Coordinate { x: 200, y: 150 },
+                Coordinate { x: 300, y: 150 },
+                Coordinate { x: 300, y: 50 },
+                Coordinate { x: 200, y: 50 },
+            ]),
+            vec![],
+        );
+
+        let result = subject.difference(&clip);
+        assert_eq!(expected, result);
+    }
+
+    #[test]
     fn test_open_offset() {
         let expected = MultiPolygon(vec![Polygon::new(
             LineString(vec![
@@ -677,6 +1124,30 @@ mod tests {
             Coordinate { x: 400.0, y: 400.0 },
         ])]);
         let result = subject.offset(5.0, JoinType::Miter(5.0), EndType::OpenSquare, 1.0);
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn test_open_offset_int() {
+        let expected = MultiPolygon(vec![Polygon::new(
+            LineString(vec![
+                Coordinate { x: 405, y: 405 },
+                Coordinate { x: 395, y: 405 },
+                Coordinate { x: 395, y: 105 },
+                Coordinate { x: 95, y: 105 },
+                Coordinate { x: 95, y: 95 },
+                Coordinate { x: 405, y: 95 },
+                Coordinate { x: 405, y: 405 },
+            ]),
+            vec![],
+        )]);
+
+        let subject = MultiLineString(vec![LineString(vec![
+            Coordinate { x: 100, y: 100 },
+            Coordinate { x: 400, y: 100 },
+            Coordinate { x: 400, y: 400 },
+        ])]);
+        let result = subject.offset(5.0, JoinType::Miter(5.0), EndType::OpenSquare);
         assert_eq!(expected, result);
     }
 }


### PR DESCRIPTION
This PR defines an alternate set of traits for `Polygon<i64>`, `MultiPolygon<i64>`, and `MultiLineString<i64>`. It needs to be a separate trait because there is no `factor` parameter for all the methods, since integer conversion isn't necessary.

I tried to use as much of the implementation from f64 types as possible, but there was a lot of unfortunate cut and paste to get versions of functions without `factor`.