### PR TITLE
Update geo-types requirement from 0.6.1 to 0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ categories = ["algorithms"]
 
 [dependencies]
 clipper-sys = "0.3.2"
-geo-types = "0.6.1"
+geo-types = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ categories = ["algorithms"]
 
 [dependencies]
 clipper-sys = "0.3.2"
-geo-types = "0.7.0"
+geo-types = "0.7.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ use clipper_sys::{
     PolyFillType_pftNonZero, PolyType, PolyType_ptClip, PolyType_ptSubject,
     Polygon as ClipperPolygon, Polygons, Vertice,
 };
-use geo_types::{Coordinate, CoordinateType, LineString, MultiLineString, MultiPolygon, Polygon};
+use geo_types::{CoordNum, Coordinate, LineString, MultiLineString, MultiPolygon, Polygon};
 use std::convert::TryInto;
 
 #[derive(Clone, Copy)]
@@ -238,10 +238,10 @@ pub trait OpenPath {}
 /// Marker trait to signify a type as an closed polygon type
 pub trait ClosedPoly {}
 
-impl<T: CoordinateType> OpenPath for MultiLineString<T> {}
-impl<T: CoordinateType> OpenPath for LineString<T> {}
-impl<T: CoordinateType> ClosedPoly for MultiPolygon<T> {}
-impl<T: CoordinateType> ClosedPoly for Polygon<T> {}
+impl<T: CoordNum> OpenPath for MultiLineString<T> {}
+impl<T: CoordNum> OpenPath for LineString<T> {}
+impl<T: CoordNum> ClosedPoly for MultiPolygon<T> {}
+impl<T: CoordNum> ClosedPoly for Polygon<T> {}
 
 #[doc(hidden)]
 pub struct OwnedPolygon {


### PR DESCRIPTION
Unfortunately I had to open a new branch as I do not have to right to push to this repo.
It should however fix the warnings of the deprecated type `CoordinateType`.